### PR TITLE
PurpleAir eliminado, columnas 2 días siguientes

### DIFF
--- a/src/Pages/Prediccion/components/Form.js
+++ b/src/Pages/Prediccion/components/Form.js
@@ -2,11 +2,10 @@ import React, { useState, useEffect } from "react";
 import { Form, Button, Col } from "react-bootstrap";
 import Select from "react-select";
 import { getSensorLocationsBySystem } from "../../../handlers/data";
-import { gasesOptions, normOptions } from "../../../constants";
 
 // Diferente a la que esta definida en constants porque este debe de decir AireNL/Sinaica junto
 const systemOptions = [
-  { value: "PurpleAir", label: "PurpleAir", opt: "P" },
+  //{ value: "PurpleAir", label: "PurpleAir", opt: "P" },
   { value: "AireNuevoLeon", label: "AireNuevoLeon", opt: "G" },
 ];
 

--- a/src/Pages/Prediccion/components/Table.js
+++ b/src/Pages/Prediccion/components/Table.js
@@ -2,7 +2,11 @@ import React from "react"
 function TablePred({
     title
 }){
-    console.log(title)
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const dayAfterTomorrow = new Date(today);
+    dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 2);
     return (
         <div>
            <div class="tableDiv">
@@ -13,13 +17,8 @@ function TablePred({
           <thead>
             <tr>
               <th class="superTableSpace">HORARIO</th>
-              <th>L</th>
-              <th>M</th>
-              <th>M</th>
-              <th>J</th>
-              <th>V</th>
-              <th>S</th>
-              <th>D</th>
+              <th>{tomorrow.toDateString()}</th>
+              <th>{dayAfterTomorrow.toDateString()}</th>
             </tr>
           </thead>
           <tbody>
@@ -27,19 +26,9 @@ function TablePred({
               <th class="titleH">Madrugada 12:00 am - 6:00 am</th>
               <th style={{ backgroundColor: "#95BF39" }}></th>
               <th style={{ backgroundColor: "#95BF39" }}></th>
-              <th style={{ backgroundColor: "#95BF39" }}></th>
-              <th style={{ backgroundColor: "#95BF39" }}></th>
-              <th style={{ backgroundColor: "#95BF39" }}></th>
-              <th style={{ backgroundColor: "#95BF39" }}></th>
-              <th style={{ backgroundColor: "#95BF39" }}></th>
             </tr>
             <tr>
               <th class="titleH">Mañana 6:00 am - 12:00 pm</th>
-              <th style={{ backgroundColor: "#F2E313" }}></th>
-              <th style={{ backgroundColor: "#F2E313" }}></th>
-              <th style={{ backgroundColor: "#F2E313" }}></th>
-              <th style={{ backgroundColor: "#F2E313" }}></th>
-              <th style={{ backgroundColor: "#F2E313" }}></th>
               <th style={{ backgroundColor: "#F2E313" }}></th>
               <th style={{ backgroundColor: "#F2E313" }}></th>
             </tr>
@@ -47,21 +36,11 @@ function TablePred({
               <th class="titleH">Tarde 12:00 pm - 6:00 pm</th>
               <th style={{ backgroundColor: "#F2811D" }}></th>
               <th style={{ backgroundColor: "#F2811D" }}></th>
-              <th style={{ backgroundColor: "#F2811D" }}></th>
-              <th style={{ backgroundColor: "#F2811D" }}></th>
-              <th style={{ backgroundColor: "#F2811D" }}></th>
-              <th style={{ backgroundColor: "#F2811D" }}></th>
-              <th style={{ backgroundColor: "#F2811D" }}></th>
             </tr>
             <tr>
               <th class="titleH" align="center">Noche 6:00 pm - 12:00 am</th>
               <th style={{ backgroundColor: "#F22233" }}></th>
               <th style={{ backgroundColor: "#F22233" }}></th>
-              <th style={{ backgroundColor: "#F22233" }}></th>
-              <th style={{ backgroundColor: "#F22233" }}></th>
-              <th style={{ backgroundColor: "#73022C" }}></th>
-              <th style={{ backgroundColor: "#73022C" }}></th>
-              <th style={{ backgroundColor: "#73022C" }}></th>
             </tr>
           </tbody>
         </table>

--- a/src/Pages/Prediccion/index.js
+++ b/src/Pages/Prediccion/index.js
@@ -2,6 +2,7 @@ import "../../App.css";
 import React, { useState } from "react";
 import Form from "./components/Form";
 import Table from "./components/Table";
+//import { apiUrl } from "../../constants";
 
 function Prediccion() {
   const [system, setSystem] = useState(null);
@@ -11,6 +12,17 @@ function Prediccion() {
   const fetchData = () => {
     setIsShown(true)
     setTitle(location.label)
+    {/*
+    fetch(`${apiUrl}/get-location-prediction?${location.label}`)
+      .then((response) => response.json())
+      .then((json) => {
+        setCalendarData(json);
+      })
+      .catch((e) => { 
+        console.log(e) 
+        setNoData(true);
+      });
+      */}
   };
   return (
     <div className="container mt-5">


### PR DESCRIPTION
El sistema de PurpleAir no forma parte de las opciones del modelo de predicción, lo dejo en comentario por si en un futuro lo agregan, el modelo de predicción devuelve solo las siguientes 50 horas por lo que en la tabla solo se mostrarán los dos días siguientes (48 horas) en las 4 secciones del día mostrando el valor más alto de las 4 horas que representan la sección del día. Aun no está conectado al endpoint de la api de predicciones.