### PR TITLE
Fix: descarga de datos del mes en /calendario

### DIFF
--- a/src/Pages/CalendarSection/index.js
+++ b/src/Pages/CalendarSection/index.js
@@ -72,7 +72,7 @@ const unidad = {
 
 function CalendarSection() {
   //Global state (Redux)
-  const { location, contaminant } = useSelector((state) => state.form);
+  const { location, contaminant, system } = useSelector((state) => state.form);
 
   const [dataByHour, setDataByHour] = useState(null);
   const [avgOptions, setAvgOptions] = useState({});
@@ -170,19 +170,19 @@ function CalendarSection() {
 
   //Build query string to download
   function getQueryStringToDownload() {
-    let queryStr = "location=";
+  if (!location || !contaminant) return null;
 
-    queryStr += location.value;
-    // Para el calendario se descarga todo el mes
-    queryStr +=
-      "&gas=" +
-      contaminant.value +
-      "&start_date=" +
-      moment().startOf("month").format("YYYY-MM-DD") +
-      "&end_date=" +
-      moment().endOf("month").format("YYYY-MM-DD");
-    return queryStr;
-  }
+  const start = moment(selectedDate).startOf("month").toISOString();
+  const end = moment(selectedDate).endOf("month").toISOString();
+
+  return (
+    `location=${location.value.id}` +
+    `&gas=${contaminant.value}` +
+    `&system=${system.opt}` +
+    `&start_date=${start}` +
+    `&end_date=${end}`
+  );
+}
 
   //Trigger file download for selected month
   function downloadFile() {


### PR DESCRIPTION
## ¿Qué cambia?

Fix FE - BE: Arreglar el boton para descargar datos del mes en la pagina de Calendario

## Evidencia

<img width="1917" height="1106" alt="image" src="https://github.com/user-attachments/assets/40cffbac-fe5d-4db5-b150-47c8a0246143" />

## ¿Cómo probarlo?

1. Abrir la página afectada.
2. Realizar la acción relacionada con el cambio.
3. Verificar que el resultado sea el esperado.

## Checklist

- [ ✅] Probado localmente
- [✅ ] No rompe funcionalidad existente
- [✅ ] Evidencia adjunta (si aplica)
