### PR TITLE
Fix: actualizar datos del calendario al cambiar filtros

### DIFF
--- a/src/Pages/CalendarSection/index.js
+++ b/src/Pages/CalendarSection/index.js
@@ -96,10 +96,10 @@ function CalendarSection() {
 
   //Fetch data when date is updated
   useEffect(() => {
-    if (location && contaminant) {
+    if (location && contaminant && avgType?.value) {
       fetchData();
     }
-  }, [selectedDate]);
+  }, [selectedDate, datesOfTheMonth, location, contaminant, avgType, system]);
 
   //Update month range when selected date changes
   useEffect(() => {
@@ -122,11 +122,6 @@ function CalendarSection() {
   }, [selectedDate]);
 
   //Fetch data when month range changes
-  useEffect(() => {
-    if (location && contaminant) {
-      fetchData();
-    }
-  }, [datesOfTheMonth]);
 
   //Fetch calendar daily data
   const fetchCalendarData = () => {


### PR DESCRIPTION
## ¿Qué cambia?

Fix FE - Actualizar los datos por hora en el calendario al seleccionar otro sensor

## Evidencia

[7_23_2026, 6_04_03 PM - Screen - Video Project.webm](https://github.com/user-attachments/assets/5c6a0142-8bc4-41c7-b1ee-80d8c3aa5a6e)


## ¿Cómo probarlo?

1. Abrir la página afectada.
2. Realizar la acción relacionada con el cambio.
3. Verificar que el resultado sea el esperado.

## Checklist

- [ ✅] Probado localmente
- [✅ ] No rompe funcionalidad existente
- [✅ ] Evidencia adjunta (si aplica)
