### PR TITLE
feature de resaltar sensor seleccionado agregada

### DIFF
--- a/src/Mapa.js
+++ b/src/Mapa.js
@@ -289,7 +289,9 @@ function MapPage() {
        */
 
       return {
-        currentLocation: location,
+        // Pass the selected location label (string) so Marcador can compare
+        // it with each marker's `locationStr` and apply the selected style.
+        currentLocation: location?.label || (location && location.value && location.value.address && location.value.address.zone) || null,
         ICAR_PM25: +data.ICAR_PM25 * 0.694,
         OMS_PM25: +data.OMS_PM25,
         AQI_PM25: +data.AQI_PM25,


### PR DESCRIPTION
## ¿Qué cambia?

Se agrego la feature de resaltar un sensor al seleccionarlo con el dropdown superior

## Evidencia
<img width="921" height="440" alt="image" src="https://github.com/user-attachments/assets/9100fa85-1b13-4029-9eb8-21667506a2ce" />
<img width="921" height="440" alt="image" src="https://github.com/user-attachments/assets/6f0374b6-cccc-4fb9-b9f1-6b0b61350763" />
<img width="921" height="438" alt="image" src="https://github.com/user-attachments/assets/90f197d4-5061-4f49-8d68-925d70cf2f1a" />


## ¿Cómo probarlo?

1. Abrir la página del mapa
2. Seleccionar un sensor utilizando el selector de arriba
3. Se deberia ver un pequeño circulo alrededor del sensor seleccionado

## Checklist

- [✅] Probado localmente
- [✅] No rompe funcionalidad existente
- [✅] Evidencia adjunta (si aplica)
