### PR TITLE
Hora de incio en la ruta /grafica seteada automaticamente a las 12 de…

### DIFF
--- a/src/Pages/Plot/index.js
+++ b/src/Pages/Plot/index.js
@@ -42,12 +42,12 @@ function GraphSection() {
   const { contaminant, location, system } = useSelector(state => state.form);
 
   // Datos de los filtros
-  const [startDate, setStartDate] = useState(moment());
+  const [startDate, setStartDate] = useState(moment().startOf("day"));
   const [endDate, setEndDate] = useState(moment());
-  const [startTime, setStartTime] = useState(moment('00:00', 'HH:mm').format("HH:mm"));
+  const [startTime, setStartTime] = useState(moment("00:00", "HH:mm").format("HH:mm"));
   const [endTime, setEndTime] = useState(moment().format("HH:mm"));
-  const [startDateTime, setStartDateTime] = useState(new Date())
-  const [endDateTime, setEndDateTime] = useState(new Date())
+  const [startDateTime, setStartDateTime] = useState(moment().startOf("day").toDate());
+  const [endDateTime, setEndDateTime] = useState(new Date());
 
 
   /**


### PR DESCRIPTION
…l dia actual

## ¿Qué cambia?

- Se modifico la ruta /grafica para que al entrar por defecto asigne la hora de inicio a las 12am del dia actual

## Evidencia

<img width="1902" height="917" alt="image" src="https://github.com/user-attachments/assets/e428e44c-2aac-4853-be48-e6a5df1e2739" />


## ¿Cómo probarlo?

1. Abrir la página afectada.
2. No deberia de aparecer el cartel de datos no encontrados
3. La fecha seleccionada automaticamente por el sistema tiene las 0:00 del dia actual

## Checklist

- [✅] Probado localmente
- [✅] No rompe funcionalidad existente
- [✅] Evidencia adjunta (si aplica)
