### PR TITLE
Fix: colorear días del calendario según calidad del aire

### DIFF
--- a/src/Pages/CalendarSection/components/Calendar.css
+++ b/src/Pages/CalendarSection/components/Calendar.css
@@ -148,35 +148,28 @@
   color: white;
 }
 .react-calendar__tile--active:enabled:hover,
-.react-calendar__tile--active:enabled:focus {
-  background: #1087ff;
-}
-.react-calendar--selectRange .react-calendar__tile--hover {
-  background-color: #e6e6e6;
-}
-
-.no-data {
+.react-calendar__tile.no-data {
   color: black !important;
   background-color: rgb(240, 239, 239);
 }
 
-.good {
-  background-color: rgb(76, 187, 23);
+.react-calendar__tile.good {
+  background-color: rgb(0, 228, 0);
 }
 
-.regular {
-  background-color: rgb(253, 218, 13);
+.react-calendar__tile.regular {
+  background-color: rgb(255, 255, 0);
 }
 
-.bad {
-  background-color: rgb(254, 0, 0);
+.react-calendar__tile.bad {
+  background-color: rgb(255, 126, 0);
 }
 
-.very-bad {
-  background-color: rgb(166, 0, 0);
+.react-calendar__tile.very-bad {
+  background-color: rgb(255, 0, 0);
 }
 
-.extremely-bad {
+.react-calendar__tile.extremely-bad {
   background-color: rgb(143, 63, 151);
 }
 

--- a/src/Pages/CalendarSection/components/Calendar.js
+++ b/src/Pages/CalendarSection/components/Calendar.js
@@ -105,10 +105,19 @@ function Calendar({ calendarData, selectedDate, setSelectedDate, datesOfTheMonth
    * @param {Date} date - Date to evaluate
    * @returns {string} - Status for the given date (e.g "good","bad")
    */
-  const getDateStatus = (date) => {
-    if (!calendarData) return;
-    return calendarData[date.getDate() - 1].status;
-  }
+  const statusToClass = {
+  good: "good",
+  regular: "regular",
+  bad: "bad",
+  very_bad: "very-bad",
+  extremely_bad: "extremely-bad",
+  ND: "no-data",
+};
+
+const getDateStatus = (date) => {
+  if (!calendarData) return;
+  return statusToClass[calendarData[date.getDate() - 1].status];
+}
   /**
    * tileClassName
    *
@@ -130,7 +139,7 @@ function Calendar({ calendarData, selectedDate, setSelectedDate, datesOfTheMonth
         return "out-of-range";
       }
     },
-    [calendarData]
+    [calendarData, datesOfTheMonth, avgType]
   );
   //Render
   return (

--- a/src/constants.js
+++ b/src/constants.js
@@ -66,7 +66,7 @@ export const statusClassOrder = [
 
 export const statusClassName = {
   Good: "good",
-  Acceptable: "acceptable",
+  Acceptable: "regular",
   Bad: "bad",
   VeryBad: "very-bad",
   ExtremelyBad: "extremely-bad",


### PR DESCRIPTION
## ¿Qué cambia?

Fix: colorear días del calendario según calidad del aire

## Evidencia

<img width="1867" height="987" alt="image" src="https://github.com/user-attachments/assets/da693ce6-bc64-45c2-860f-917482529da2" />

## ¿Cómo probarlo?

1. Abrir la página afectada.
2. Realizar la acción relacionada con el cambio.
3. Verificar que el resultado sea el esperado.

## Checklist

- [✅] Probado localmente
- [✅] No rompe funcionalidad existente
- [✅] Evidencia adjunta (si aplica)
